### PR TITLE
addon-updaterの更新

### DIFF
--- a/addon/globalPlugins/VSU/constants.py
+++ b/addon/globalPlugins/VSU/constants.py
@@ -11,6 +11,7 @@ addonRootDir = os.path.abspath(os.path.join(addonDir, "..", ".."))
 
 curAddon = addonHandler.Addon(addonRootDir)
 addonName = curAddon.manifest["name"]
+addonKeyword = curAddon.manifest["keyword"]
 addonSummary = curAddon.manifest["summary"]
 addonVersion = curAddon.manifest["version"]
 addonDocFileName = curAddon.manifest["docFileName"]

--- a/addon/globalPlugins/VSU/updater.py
+++ b/addon/globalPlugins/VSU/updater.py
@@ -46,7 +46,7 @@ def confirm(message, title):
     if isCompatibleWith2025():
         return gui.message.MessageDialog.confirm(message, title) == gui.message.ReturnCode.OK
     else:
-        return gui.messageBox(message, title, style=wx.CENTER | wx.OK | wx.CANCEL | wx.ICON_INFORMATION) == wx.ID_OK
+        return gui.messageBox(message, title, style=wx.CENTER | wx.OK | wx.CANCEL | wx.ICON_INFORMATION) == wx.OK
 
 
 class AutoUpdateChecker:
@@ -99,7 +99,7 @@ class NVDAAddOnUpdater ():
             update_dict = json.loads(update_dict)
         except BaseException:
             if self.mode == MANUAL:
-                gui.messageBox(strs.ERROR_UPDATE_INFO_INVALID, strs.ERROR)
+                messageBox(strs.ERROR_UPDATE_INFO_INVALID, strs.ERROR)
             return False
 
         code = update_dict["code"]

--- a/addon/globalPlugins/VSU/updater.py
+++ b/addon/globalPlugins/VSU/updater.py
@@ -1,5 +1,3 @@
-# coding: UTF-8
-
 from __future__ import unicode_literals
 import addonHandler
 import globalVars
@@ -19,12 +17,7 @@ from urllib.request import Request, urlopen
 from urllib.parse import urlencode
 from .constants import *
 from .translate import *
-
-try:
-    import addonHandler
-    addonHandler.initTranslation()
-except BaseException:
-    def _(x): return x
+from . import updaterStrings as strs
 
 try:
     import updateCheck
@@ -40,13 +33,33 @@ except RuntimeError:
 AUTO=0
 MANUAL=1
 
+def isCompatibleWith2025():
+    return versionInfo.version_year >= 2025
+
+def messageBox(message, title):
+    if isCompatibleWith2025():
+        gui.message.MessageDialog.alert(message, title)
+    else:
+        gui.messageBox(message, title, style=wx.CENTER)
+
+def confirm(message, title):
+    if isCompatibleWith2025():
+        return gui.message.MessageDialog.confirm(message, title) == gui.message.ReturnCode.OK
+    else:
+        return gui.messageBox(message, title, style=wx.CENTER | wx.OK | wx.CANCEL | wx.ICON_INFORMATION) == wx.ID_OK
+
+
 class AutoUpdateChecker:
     def __init__(self):
         self.updater = None
         if not updatable:
             log.warning("Update check not supported.")
 
-    def autoUpdateCheck(self, mode=0):
+    def autoUpdateCheck(self, mode=AUTO):
+        """
+        Call this method to check for updates. mode=AUTO means automatic update check, and MANUAL means manual triggering like "check for updates" menu invocation.
+        When set to AUTO mode, some dialogs are not displayed (latest and error).
+        """
         if not updatable:
             return
         self.updater = NVDAAddOnUpdater(mode)
@@ -61,8 +74,9 @@ class NVDAAddOnUpdater ():
             t.start()
 
     def check_update(self):
+        """Called as the thread entry point."""
         post_params = {
-            "name": addonName,
+            "name": addonKeyword,
             "version": addonVersion,
             "updater_version": "1.0.0",
         }
@@ -71,13 +85,12 @@ class NVDAAddOnUpdater ():
             f = urlopen(req)
         except BaseException:
             if self.mode == MANUAL:
-                gui.messageBox(_("Unable to connect to update server.\nCheck your internet connection."),
-                               _("Error"), style=wx.CENTER | wx.ICON_WARNING)
+                messageBox(strs.ERROR_UNABLE_TO_CONNECT, strs.ERROR)
             return False
 
         if f.getcode() != 200:
             if self.mode == MANUAL:
-                gui.messageBox(_("Unable to connect to update server."), _("Error"), style=wx.CENTER | wx.ICON_WARNING)
+                messageBox(strs.ERROR_UNABLE_TO_CONNECT_SERVERSIDE, strs.ERROR)
             return False
 
         try:
@@ -86,31 +99,25 @@ class NVDAAddOnUpdater ():
             update_dict = json.loads(update_dict)
         except BaseException:
             if self.mode == MANUAL:
-                gui.messageBox(
-                    _("The update information is invalid.\nPlease contact ACT Laboratory for further information."),
-                    _("Error"),
-                    style=wx.CENTER | wx.ICON_WARNING)
+                gui.messageBox(strs.ERROR_UPDATE_INFO_INVALID, strs.ERROR)
             return False
 
         code = update_dict["code"]
         if code == UPDATER_LATEST:
             if self.mode == MANUAL:
-                gui.messageBox(_("No updates found.\nYou are using the latest version."), _("Update check"), style=wx.CENTER | wx.ICON_INFORMATION)
+                messageBox(strs.NO_UPDATES, strs.UPDATE_CHECK_TITLE)
             return False
         elif code == UPDATER_BAD_PARAM:
             if self.mode == MANUAL:
-                gui.messageBox(_("The request parameter is invalid. Please contact the developer."),
-                               _("Update check"), style=wx.CENTER | wx.ICON_INFORMATION)
+                messageBox(strs.ERROR_REQUEST_PARAMETERS_INVALID, strs.UPDATE_CHECK_TITLE)
             return False
         elif code == UPDATER_NOT_FOUND:
             if self.mode == MANUAL:
-                gui.messageBox(_("The updater is not registered. Please contact the developer."),
-                               _("Update check"), style=wx.CENTER | wx.ICON_INFORMATION)
+                messageBox(strs.UPDATER_NOT_REGISTERED, strs.UPDATE_CHECK_TITLE)
             return False
         elif code == UPDATER_VISIT_SITE:
             if self.mode == MANUAL:
-                gui.messageBox(_("An update was found, but updating from the current version is not possible. Please visit the software's website. "),
-                               _("Update check"), style=wx.CENTER | wx.ICON_INFORMATION)
+                messageBox(strs.UPDATE_NOT_POSSIBLE, strs.UPDATE_CHECK_TITLE)
             return False
 
         new_version = update_dict["update_version"]
@@ -121,11 +128,11 @@ class NVDAAddOnUpdater ():
             hash = update_dict["updater_hash"]
         # end set hash
 
-        caption = _("Update confirmation")
-        question = _("{summary} Ver.{newVersion} is available.\nWould you like to update?\nCurrent version: {currentVersion}\nNew version: {newVersion}").format(
+        caption = strs.UPDATE_CONFIRMATION_TITLE
+        question = strs.UPDATE_CONFIRMATION_MESSAGE.format(
             summary=addonSummary, newVersion=new_version, currentVersion=addonVersion)
-        answer = gui.messageBox(question, caption, style=wx.CENTER | wx.OK | wx.CANCEL | wx.CANCEL_DEFAULT | wx.ICON_INFORMATION)
-        if answer == wx.OK:
+        answer = confirm(question, caption)
+        if answer == True:
             downloader = UpdateDownloader(addonName, [url], hash)
             wx.CallAfter(downloader.start)
             return
@@ -148,8 +155,8 @@ class UpdateDownloader(updateCheck.UpdateDownloader):
         self._shouldCancel = False
         self._guiExecTimer = wx.PyTimer(self._guiExecNotify)
         gui.mainFrame.prePopup()
-        self._progressDialog = wx.ProgressDialog(_("Downloading add-on update"),
-                                                 _("Connecting"),
+        self._progressDialog = wx.ProgressDialog(strs.DOWNLOADING,
+                                                 strs.CONNECTING,
                                                  style=wx.PD_CAN_ABORT | wx.PD_ELAPSED_TIME | wx.PD_REMAINING_TIME | wx.PD_AUTO_HIDE,
                                                  parent=gui.mainFrame)
         self._progressDialog.Raise()
@@ -160,10 +167,7 @@ class UpdateDownloader(updateCheck.UpdateDownloader):
     def _error(self):
         self._stopped()
         self.cleanup_tempfile()
-        gui.messageBox(
-            _("Error downloading add-on update."),
-            translate("Error"),
-            wx.OK | wx.ICON_ERROR)
+        messageBox(strs.ERROR_DOWNLOADING, strs.ERROR)
 
     def _download(self, url):
         headers = {}
@@ -211,8 +215,6 @@ class UpdateDownloader(updateCheck.UpdateDownloader):
 
     def _downloadSuccess(self):
         self._stopped()
-        from gui import addonGui
-        closeAfter = addonGui.AddonsDialog._instance is None or (versionInfo.version_year, versionInfo.version_major) >= (2019, 1)
         try:
             try:
                 bundle = addonHandler.AddonBundle(self.destPath.decode("mbcs"))
@@ -220,9 +222,7 @@ class UpdateDownloader(updateCheck.UpdateDownloader):
                 bundle = addonHandler.AddonBundle(self.destPath)
             except BaseException:
                 log.error("Error opening addon bundle from %s" % self.destPath, exc_info=True)
-                gui.messageBox(translate("Failed to open add-on package file at %s - missing file or invalid file format") % self.destPath,
-                               translate("Error"),
-                               wx.OK | wx.ICON_ERROR)
+                messageBox(strs.ERROR_OPENING % self.destPath, strs.ERROR)
                 return
             bundleName = bundle.manifest['name']
             for addon in addonHandler.getAvailableAddons():
@@ -230,29 +230,23 @@ class UpdateDownloader(updateCheck.UpdateDownloader):
                     addon.requestRemove()
                     break
             progressDialog = gui.IndeterminateProgressDialog(gui.mainFrame,
-                                                             _("Updating add-on"),
-                                                             _("Please wait while the add-on is being updated."))
+                                                             strs.UPDATING,
+                                                             strs.UPDATING_PLEASE_WAIT)
             try:
                 gui.ExecAndPump(addonHandler.installAddonBundle, bundle)
             except BaseException:
                 log.error("Error installing  addon bundle from %s" % self.destPath, exc_info=True)
-                if not closeAfter:
-                    addonGui.AddonsDialog(gui.mainFrame).refreshAddonsList()
                 progressDialog.done()
                 del progressDialog
-                gui.messageBox(_("Failed to update add-on  from %s.") % self.destPath,
-                               translate("Error"),
-                               wx.OK | wx.ICON_ERROR)
+                messageBox(strs.ERROR_FAILED_TO_UPDATE % self.destPath, strs.ERROR)
                 return
             else:
-                if not closeAfter:
-                    addonGui.AddonsDialog(gui.mainFrame).refreshAddonsList(activeIndex=-1)
                 progressDialog.done()
                 del progressDialog
         finally:
             self.cleanup_tempfile()
-            if closeAfter:
-                wx.CallLater(1, addonGui.AddonsDialog(gui.mainFrame).Close)
+            from gui import addonGui
+            addonGui.promptUserForRestart()
 
     def cleanup_tempfile(self):
         if not os.path.isfile(self.destPath):

--- a/addon/globalPlugins/VSU/updaterStrings.py
+++ b/addon/globalPlugins/VSU/updaterStrings.py
@@ -1,0 +1,24 @@
+try:
+    import addonHandler
+    addonHandler.initTranslation()
+except BaseException:
+    def _(x): return x
+
+ERROR = _("Error")
+ERROR_UNABLE_TO_CONNECT = _("Unable to connect to update server.\nCheck your internet connection.")
+ERROR_UNABLE_TO_CONNECT_SERVERSIDE = _("Unable to connect to update server.")
+ERROR_UPDATE_INFO_INVALID = _("The update information is invalid.\nPlease contact ACT Laboratory for further information.")
+ERROR_REQUEST_PARAMETERS_INVALID = _("The request parameter is invalid. Please contact the developer.")
+ERROR_DOWNLOADING = _("Error downloading add-on update.")
+ERROR_OPENING = _("Failed to open add-on package file at %s - missing file or invalid file format")
+ERROR_FAILED_TO_UPDATE = _("Failed to update add-on  from %s.")
+NO_UPDATES = _("No updates found.\nYou are using the latest version.")
+UPDATER_NOT_REGISTERED = _("The updater is not registered. Please contact the developer.")
+UPDATE_NOT_POSSIBLE = _("An update was found, but updating from the current version is not possible. Please visit the software's website. ")
+UPDATE_CHECK_TITLE = _("Update check")
+UPDATE_CONFIRMATION_TITLE = _("Update confirmation")
+UPDATE_CONFIRMATION_MESSAGE = _("{summary} Ver.{newVersion} is available.\nWould you like to update?\nCurrent version: {currentVersion}\nNew version: {newVersion}")
+DOWNLOADING = _("Downloading add-on update")
+CONNECTING = _("Connecting")
+UPDATING = _("Updating add-on")
+UPDATING_PLEASE_WAIT = _("Please wait while the add-on is being updated.")

--- a/buildVars.py
+++ b/buildVars.py
@@ -23,6 +23,7 @@ ADDON_KEYWORD = "VSU"
 addon_info = {
     # add-on Name/identifier, internal for NVDA
     "addon_name": "VSU",
+    "addon_keyword": "VSU",
     # Add-on summary, usually the user visible name of the addon.
     # Translators: Summary for this add-on
     # to be shown on installation and add-on information found in Add-ons Manager.

--- a/manifest.ini.tpl
+++ b/manifest.ini.tpl
@@ -1,4 +1,5 @@
 name = {addon_name}
+keyword = {addon_keyword}
 summary = "{addon_summary}"
 description = """{addon_description}"""
 author = "{addon_author}"


### PR DESCRIPTION
# このPRでやっていること
- addon-updaterを最新バージョンに更新します
- NVDA 2025.1以降のバージョンと、それ以前のバージョンに両方対応するように調整してあります
- また、アドオンのベース言語がどちらでも使えるように、文字列の定義が分かれたりしています

# やってもらいたいこと
以下の確認をお願いします
- [ ] NVDA 2024.4でアップデーターが動作すること
- [ ] NVDA 2025.1のスナップショット版でアップデーターが動作すること

私はとりあえず全部のアドオンにワールドツアーして回るので、動作確認は、アドオンを主担当した人にお願いしたいです。
実際にアップデートできるまでテストしてもらえると助かります。ローカルだけバージョン番号を下げることでテストできると思います。
